### PR TITLE
hide gRPC class for etcd lease

### DIFF
--- a/src/main/java/com/coreos/jetcd/EtcdLease.java
+++ b/src/main/java/com/coreos/jetcd/EtcdLease.java
@@ -1,11 +1,11 @@
 package com.coreos.jetcd;
 
-import com.coreos.jetcd.api.LeaseGrantResponse;
 import com.coreos.jetcd.api.LeaseKeepAliveResponse;
-import com.coreos.jetcd.api.LeaseRevokeResponse;
+import com.coreos.jetcd.data.EtcdHeader;
+import com.coreos.jetcd.lease.Lease;
 import com.coreos.jetcd.lease.NoSuchLeaseException;
-import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -19,47 +19,47 @@ public interface EtcdLease {
      * @param ttl ttl value, unit seconds
      * @return
      */
-    ListenableFuture<LeaseGrantResponse> grant(long ttl);
+    CompletableFuture<Lease> grant(long ttl);
 
     /**
      * revoke one lease and the key bind to this lease will be removed
      *
-     * @param leaseId id of the lease to revoke
+     * @param lease lease to revoke
      * @return
      */
-    ListenableFuture<LeaseRevokeResponse> revoke(long leaseId);
+    CompletableFuture<EtcdHeader> revoke(Lease lease);
 
     /**
      * keep alive one lease in background
      *
-     * @param leaseId          id of lease to set handler
+     * @param lease            lease to set handler
      * @param etcdLeaseHandler the handler for the lease, this value can be null
      */
-    void keepAlive(long leaseId, EtcdLeaseHandler etcdLeaseHandler);
+    void keepAlive(Lease lease, EtcdLeaseHandler etcdLeaseHandler);
 
     /**
      * cancel keep alive for lease in background
      *
-     * @param leaseId          id of lease
-    */
-    void cancelKeepAlive(long leaseId) throws ExecutionException, InterruptedException;
+     * @param lease lease
+     */
+    void cancelKeepAlive(Lease lease) throws ExecutionException, InterruptedException;
 
     /**
      * keep alive one lease only once
      *
-     * @param leaseId id of lease to keep alive once
+     * @param lease lease to keep alive once
      * @return The keep alive response
      */
-    ListenableFuture<LeaseKeepAliveResponse> keepAliveOnce(long leaseId);
+    CompletableFuture<EtcdHeader> keepAliveOnce(Lease lease);
 
     /**
      * set EtcdLeaseHandler for lease
      *
-     * @param leaseId          id of the lease to set handler
+     * @param lease            the lease to set handler
      * @param etcdLeaseHandler the handler for the lease
      * @throws NoSuchLeaseException if lease do not exist
      */
-    void setEtcdLeaseHandler(long leaseId, EtcdLeaseHandler etcdLeaseHandler) throws NoSuchLeaseException;
+    void setEtcdLeaseHandler(Lease lease, EtcdLeaseHandler etcdLeaseHandler) throws NoSuchLeaseException;
 
     /**
      * Init the request stream to etcd
@@ -78,6 +78,7 @@ public interface EtcdLease {
 
     /**
      * It hints the state of the keep alive service.
+     *
      * @return whether the keep alive service is running.
      */
     boolean isKeepAliveServiceRunning();

--- a/src/main/java/com/coreos/jetcd/EtcdLeaseImpl.java
+++ b/src/main/java/com/coreos/jetcd/EtcdLeaseImpl.java
@@ -1,23 +1,22 @@
 package com.coreos.jetcd;
 
+import com.coreos.jetcd.api.*;
+import com.coreos.jetcd.data.EtcdHeader;
+import com.coreos.jetcd.lease.Lease;
+import com.coreos.jetcd.lease.NoSuchLeaseException;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.ManagedChannel;
+import io.grpc.stub.StreamObserver;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.*;
 
-import com.coreos.jetcd.api.LeaseGrantRequest;
-import com.coreos.jetcd.api.LeaseGrantResponse;
-import com.coreos.jetcd.api.LeaseGrpc;
-import com.coreos.jetcd.api.LeaseKeepAliveRequest;
-import com.coreos.jetcd.api.LeaseKeepAliveResponse;
-import com.coreos.jetcd.api.LeaseRevokeRequest;
-import com.coreos.jetcd.api.LeaseRevokeResponse;
-import com.coreos.jetcd.lease.Lease;
-import com.coreos.jetcd.lease.NoSuchLeaseException;
-import com.google.common.util.concurrent.ListenableFuture;
-import io.grpc.ManagedChannel;
-import io.grpc.stub.StreamObserver;
+import static com.coreos.jetcd.EtcdUtil.*;
 
 /**
  * Implementation of lease client
@@ -37,9 +36,11 @@ public class EtcdLeaseImpl implements EtcdLease {
      */
     private ScheduledExecutorService               keepAliveSchedule;
     private ScheduledFuture<?>                     scheduledFuture;
+    private Supplier<Executor>                     callExecutor;
     private long                                   scanPeriod;
 
-    private final Map<Long, Lease>                 keepAlives            = new ConcurrentHashMap<>();
+    private final Map<Long, LeaseHolder>                 keepAlives            = new ConcurrentHashMap<>();
+    private final Map<Long, CompletableFuture<EtcdHeader>>    onceKeepAlives = new ConcurrentHashMap<>();
 
     /**
      * The first time interval
@@ -65,6 +66,7 @@ public class EtcdLeaseImpl implements EtcdLease {
         this.leaseFutureStub = EtcdClientUtil.configureStub(LeaseGrpc.newFutureStub(this.channel), token);
         this.leaseStub = EtcdClientUtil.configureStub(LeaseGrpc.newStub(this.channel), token);
         this.scanPeriod = DEFAULT_SCAN_PERIOD;
+        callExecutor = Suppliers.memoize(()->Executors.newSingleThreadExecutor());
     }
 
     /**
@@ -87,9 +89,9 @@ public class EtcdLeaseImpl implements EtcdLease {
                 @Override
                 public void onNext(LeaseKeepAliveResponse leaseKeepAliveResponse) {
                     processKeepAliveRespond(leaseKeepAliveResponse);
-                    Lease lease = keepAlives.get(leaseKeepAliveResponse.getID());
-                    if (lease != null && lease.isContainHandler()) {
-                        lease.getEtcdLeaseHandler().onKeepAliveRespond(leaseKeepAliveResponse);
+                    LeaseHolder leaseHolder = keepAlives.get(leaseKeepAliveResponse.getID());
+                    if (leaseHolder != null && leaseHolder.isContainHandler()) {
+                        leaseHolder.getEtcdLeaseHandler().onKeepAliveRespond(leaseKeepAliveResponse);
                     }
                 }
 
@@ -144,21 +146,25 @@ public class EtcdLeaseImpl implements EtcdLease {
      * @return
      */
     @Override
-    public ListenableFuture<LeaseGrantResponse> grant(long ttl) {
+    public CompletableFuture<Lease> grant(long ttl) {
         LeaseGrantRequest leaseGrantRequest = LeaseGrantRequest.newBuilder().setTTL(ttl).build();
-        return this.leaseFutureStub.leaseGrant(leaseGrantRequest);
+        return completableFromListenableFuture(this.leaseFutureStub.leaseGrant(leaseGrantRequest),
+                (LeaseGrantResponse l)->apiToClientLease(l),
+                callExecutor.get());
     }
 
     /**
      * revoke one lease and the key bind to this lease will be removed
      *
-     * @param leaseId id of the lease to revoke
+     * @param lease the lease to revoke
      * @return
      */
     @Override
-    public ListenableFuture<LeaseRevokeResponse> revoke(long leaseId) {
-        LeaseRevokeRequest leaseRevokeRequest = LeaseRevokeRequest.newBuilder().setID(leaseId).build();
-        return this.leaseFutureStub.leaseRevoke(leaseRevokeRequest);
+    public CompletableFuture<EtcdHeader> revoke(Lease lease) {
+        LeaseRevokeRequest leaseRevokeRequest = LeaseRevokeRequest.newBuilder().setID(lease.getLeaseID()).build();
+        return completableFromListenableFuture(this.leaseFutureStub.leaseRevoke(leaseRevokeRequest),
+                (LeaseRevokeResponse l)->apiToClientHeader(l.getHeader(), -1),
+                callExecutor.get());
     }
 
     /**
@@ -166,37 +172,37 @@ public class EtcdLeaseImpl implements EtcdLease {
      * user thread, it can be thread unsafe, so we sync function here
      * to avoid put twice.
      *
-     * @param leaseId          id of lease to set handler
+     * @param lease          of lease to set handler
      * @param etcdLeaseHandler the handler for the lease, this value can be null
      *
      * @throws IllegalStateException this exception hints that the keep alive service wasn't started
      */
     @Override
-    public synchronized void keepAlive(long leaseId, EtcdLeaseHandler etcdLeaseHandler) {
+    public synchronized void keepAlive(Lease lease, EtcdLeaseHandler etcdLeaseHandler) {
         if(!isKeepAliveServiceRunning()){
             throw new IllegalStateException("Lease keep alive service not started yet");
         }
-        if (!this.keepAlives.containsKey(leaseId)) {
-            Lease lease = new Lease(leaseId, etcdLeaseHandler);
+        if (!this.keepAlives.containsKey(lease.getLeaseID())) {
+            LeaseHolder leaseHolder = new LeaseHolder(lease, etcdLeaseHandler);
             long now = System.currentTimeMillis();
-            lease.setNextKeepAlive(now).setDeadLine(now + firstKeepAliveTimeOut);
-            this.keepAlives.put(leaseId, lease);
+            leaseHolder.setNextKeepAlive(now).setDeadLine(now + firstKeepAliveTimeOut);
+            this.keepAlives.put(lease.getLeaseID(), leaseHolder);
         }
     }
 
     /**
      * cancel keep alive for lease in background
      *
-     * @param leaseId id of lease
+     * @param lease lease to cancel keep alive
      */
     @Override
-    public synchronized void cancelKeepAlive(long leaseId) throws ExecutionException, InterruptedException {
+    public synchronized void cancelKeepAlive(Lease lease) throws ExecutionException, InterruptedException {
         if(!isKeepAliveServiceRunning()){
             throw new IllegalStateException("Lease keep alive service not started yet");
         }
-        if (this.keepAlives.containsKey(leaseId)) {
-            keepAlives.remove(leaseId);
-            revoke(leaseId).get();
+        if (this.keepAlives.containsKey(lease.getLeaseID())) {
+            keepAlives.remove(lease.getLeaseID());
+            revoke(lease).get();
         }else{
             throw new IllegalStateException("Lease is not registered in the keep alive service");
         }
@@ -205,42 +211,43 @@ public class EtcdLeaseImpl implements EtcdLease {
     /**
      * keep alive one lease only once
      *
-     * @param leaseId id of lease to keep alive once
+     * @param lease lease to keep alive once
      * @return The keep alive response
      */
     @Override
-    public ListenableFuture<LeaseKeepAliveResponse> keepAliveOnce(long leaseId) {
-
-        /**
-         * to be completed, I will return a ListenableFuture value in the future
-         */
-        StreamObserver<LeaseKeepAliveRequest> requestObserver = this.leaseStub.leaseKeepAlive(keepAliveResponseStreamObserver);
-        requestObserver.onNext(newKeepAliveRequest(leaseId));
-        requestObserver.onCompleted();
-
-        throw new UnsupportedOperationException();
+    public synchronized CompletableFuture<EtcdHeader> keepAliveOnce(Lease lease) {
+        if(keepAlives.containsKey(lease.getLeaseID())||onceKeepAlives.containsKey(lease.getLeaseID())){
+            throw new IllegalStateException("lease already registered in keep alive service");
+        }
+        if(!isKeepAliveServiceRunning()){
+            throw new IllegalStateException("Lease keep alive service not started yet");
+        }
+        CompletableFuture<EtcdHeader> completableFuture = new CompletableFuture<>();
+        onceKeepAlives.put(lease.getLeaseID(), completableFuture);
+        this.keepAliveRequestStreamObserver.onNext(newKeepAliveRequest(lease.getLeaseID()));
+        return completableFuture;
     }
 
     /**
      * set EtcdLeaseHandler for lease
      *
-     * @param leaseId          id of the lease to set handler
+     * @param lease          lease to set handler
      * @param etcdLeaseHandler the handler for the lease
      * @throws NoSuchLeaseException if lease do not exist
      */
     @Override
-    public void setEtcdLeaseHandler(long leaseId, EtcdLeaseHandler etcdLeaseHandler) throws NoSuchLeaseException {
-        Lease lease = this.keepAlives.get(leaseId);
-        if (lease != null) {
+    public void setEtcdLeaseHandler(Lease lease, EtcdLeaseHandler etcdLeaseHandler) throws NoSuchLeaseException {
+        LeaseHolder leaseHolder = this.keepAlives.get(lease.getLeaseID());
+        if (leaseHolder != null) {
             /**
              * This function may be called with different threads, so
              * we sync here to do it sequentially.
              */
-            synchronized (lease) {
-                lease.setEtcdLeaseHandler(etcdLeaseHandler);
+            synchronized (leaseHolder) {
+                leaseHolder.setEtcdLeaseHandler(etcdLeaseHandler);
             }
         } else {
-            throw new NoSuchLeaseException(leaseId);
+            throw new NoSuchLeaseException(lease.getLeaseID());
         }
     }
 
@@ -253,9 +260,9 @@ public class EtcdLeaseImpl implements EtcdLease {
     private void keepAliveExecutor() {
         long now = System.currentTimeMillis();
         List<Long> toSendIds = new ArrayList<>();
-        for (Lease l : this.keepAlives.values()) {
+        for (LeaseHolder l : this.keepAlives.values()) {
             if (now > l.getNextKeepAlive()) {
-                toSendIds.add(l.getLeaseID());
+                toSendIds.add(l.lease.getLeaseID());
             }
         }
 
@@ -273,14 +280,14 @@ public class EtcdLeaseImpl implements EtcdLease {
     private void deadLineExecutor() {
         long now = System.currentTimeMillis();
         List<Long> expireLeases = new ArrayList<>();
-        for (Lease l : this.keepAlives.values()) {
+        for (LeaseHolder l : this.keepAlives.values()) {
             if (now > l.getDeadLine()) {
-                expireLeases.add(l.getLeaseID());
+                expireLeases.add(l.lease.getLeaseID());
             }
         }
 
         for (Long id : expireLeases) {
-            Lease lease = this.keepAlives.get(id);
+            LeaseHolder lease = this.keepAlives.get(id);
             if (lease != null && lease.isContainHandler()) {
                 lease.getEtcdLeaseHandler().onLeaseExpired(id);
             }
@@ -295,24 +302,26 @@ public class EtcdLeaseImpl implements EtcdLease {
      */
     public void processKeepAliveRespond(LeaseKeepAliveResponse leaseKeepAliveResponse) {
         long id = leaseKeepAliveResponse.getID();
-        Lease lease = this.keepAlives.get(id);
-        if (lease != null) {
+        LeaseHolder leaseHolder = this.keepAlives.get(id);
+        if (leaseHolder != null) {
             /**
              * This function is called by stream callback from different thread, so
              * we sync here to make the lease set sequentially.
              */
-            synchronized (lease) {
+            synchronized (leaseHolder) {
                 if (leaseKeepAliveResponse.getTTL() <= 0) {
-                    if (lease != null && lease.isContainHandler()) {
-                        lease.getEtcdLeaseHandler().onLeaseExpired(id);
+                    if (leaseHolder != null && leaseHolder.isContainHandler()) {
+                        leaseHolder.getEtcdLeaseHandler().onLeaseExpired(id);
                     }
                     removeLease(id);
                 } else {
                     long nextKeepAlive = System.currentTimeMillis() + 1000 + leaseKeepAliveResponse.getTTL() * 1000 / 3;
-                    lease.setNextKeepAlive(nextKeepAlive);
-                    lease.setDeadLine(System.currentTimeMillis() + leaseKeepAliveResponse.getTTL() * 1000);
+                    leaseHolder.setNextKeepAlive(nextKeepAlive);
+                    leaseHolder.setDeadLine(System.currentTimeMillis() + leaseKeepAliveResponse.getTTL() * 1000);
                 }
             }
+        }else if(onceKeepAlives.containsKey(id)){
+            onceKeepAlives.remove(id).complete(apiToClientHeader(leaseKeepAliveResponse.getHeader(), -1));
         }
     }
 
@@ -361,4 +370,58 @@ public class EtcdLeaseImpl implements EtcdLease {
             }
         }
     }
+
+    static class LeaseHolder{
+
+        final Lease lease;
+
+        private LeaseGrantResponse         leaseGrantResponse;
+
+        private long                       deadLine;
+
+        private long                       nextKeepAlive;
+
+        private EtcdLease.EtcdLeaseHandler etcdLeaseHandler;
+
+        public LeaseHolder(Lease lease) {
+            this.lease = lease;
+        }
+
+        public LeaseHolder(Lease lease, EtcdLeaseHandler etcdLeaseHandler) {
+            this.lease = lease;
+            this.etcdLeaseHandler = etcdLeaseHandler;
+        }
+
+        public long getDeadLine() {
+            return deadLine;
+        }
+
+        LeaseHolder setDeadLine(long deadLine) {
+            this.deadLine = deadLine;
+            return this;
+        }
+
+        public long getNextKeepAlive() {
+            return nextKeepAlive;
+        }
+
+        public LeaseHolder setNextKeepAlive(long nextKeepAlive) {
+            this.nextKeepAlive = nextKeepAlive;
+            return this;
+        }
+
+        public boolean isContainHandler() {
+            return etcdLeaseHandler != null;
+        }
+
+        public EtcdLease.EtcdLeaseHandler getEtcdLeaseHandler() {
+            return etcdLeaseHandler;
+        }
+
+        public void setEtcdLeaseHandler(EtcdLease.EtcdLeaseHandler etcdLeaseHandler) {
+            this.etcdLeaseHandler = etcdLeaseHandler;
+        }
+    }
+
+
 }

--- a/src/main/java/com/coreos/jetcd/lease/Lease.java
+++ b/src/main/java/com/coreos/jetcd/lease/Lease.java
@@ -2,64 +2,30 @@ package com.coreos.jetcd.lease;
 
 import com.coreos.jetcd.EtcdLease;
 import com.coreos.jetcd.api.LeaseGrantResponse;
+import com.coreos.jetcd.data.EtcdHeader;
 
 /**
  * The Lease hold the keepAlive information for lease
  */
 public class Lease {
 
+    public final EtcdHeader header;
+
     private final long                 leaseID;
 
-    private long                       ttl;
+    private final long                       ttl;
 
-    private LeaseGrantResponse         leaseGrantResponse;
-
-    private long                       deadLine;
-
-    private long                       nextKeepAlive;
-
-    private EtcdLease.EtcdLeaseHandler etcdLeaseHandler;
-
-    public Lease(long leaseID) {
-        this(leaseID, null);
-    }
-
-    public Lease(long leaseID, EtcdLease.EtcdLeaseHandler etcdLeaseHandler) {
+    public Lease(long leaseID, long ttl, EtcdHeader header) {
+        this.header = header;
         this.leaseID = leaseID;
-        this.etcdLeaseHandler = etcdLeaseHandler;
+        this.ttl = ttl;
     }
 
     public long getLeaseID() {
         return leaseID;
     }
 
-    public long getDeadLine() {
-        return deadLine;
-    }
-
-    public Lease setDeadLine(long deadLine) {
-        this.deadLine = deadLine;
-        return this;
-    }
-
-    public long getNextKeepAlive() {
-        return nextKeepAlive;
-    }
-
-    public Lease setNextKeepAlive(long nextKeepAlive) {
-        this.nextKeepAlive = nextKeepAlive;
-        return this;
-    }
-
-    public boolean isContainHandler() {
-        return etcdLeaseHandler != null;
-    }
-
-    public EtcdLease.EtcdLeaseHandler getEtcdLeaseHandler() {
-        return etcdLeaseHandler;
-    }
-
-    public void setEtcdLeaseHandler(EtcdLease.EtcdLeaseHandler etcdLeaseHandler) {
-        this.etcdLeaseHandler = etcdLeaseHandler;
+    public long getTtl() {
+        return ttl;
     }
 }

--- a/src/main/java/com/coreos/jetcd/options/PutOption.java
+++ b/src/main/java/com/coreos/jetcd/options/PutOption.java
@@ -1,5 +1,7 @@
 package com.coreos.jetcd.options;
 
+import com.coreos.jetcd.lease.Lease;
+
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
@@ -27,13 +29,13 @@ public final class PutOption {
         /**
          * Assign a <i>leaseId</i> for a put operation. Zero means no lease.
          *
-         * @param leaseId lease id to apply to a put operation
+         * @param lease lease to apply to a put operation
          * @return builder
          * @throws IllegalArgumentException if lease is less than zero.
          */
-        public Builder withLeaseId(long leaseId) {
-            checkArgument(leaseId >= 0, "leaseId should greater than or equal to zero: leaseId=%s", leaseId);
-            this.leaseId = leaseId;
+        public Builder withLeaseId(Lease lease) {
+            checkArgument(lease.getLeaseID() >= 0, "leaseId should greater than or equal to zero: leaseId=%s", lease.getLeaseID());
+            this.leaseId = lease.getLeaseID();
             return this;
         }
 

--- a/src/test/java/com/coreos/jetcd/EtcdKVTest.java
+++ b/src/test/java/com/coreos/jetcd/EtcdKVTest.java
@@ -1,5 +1,6 @@
 package com.coreos.jetcd;
 
+import com.coreos.jetcd.lease.Lease;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.testng.asserts.Assertion;
@@ -48,7 +49,7 @@ public class EtcdKVTest {
     public void testPutWithNotExistLease() throws Exception {
         ByteString sampleKey = ByteString.copyFrom("sample_key", "UTF-8");
         ByteString sampleValue = ByteString.copyFrom("sample_value", "UTF-8");
-        PutOption option = PutOption.newBuilder().withLeaseId(99999).build();
+        PutOption option = PutOption.newBuilder().withLeaseId(new Lease(9999,5, null)).build();
         ListenableFuture<PutResponse> feature = kvClient.put(sampleKey, sampleValue, option);
         try {
             PutResponse response = feature.get();

--- a/src/test/java/com/coreos/jetcd/EtcdLeaseTest.java
+++ b/src/test/java/com/coreos/jetcd/EtcdLeaseTest.java
@@ -1,19 +1,13 @@
 package com.coreos.jetcd;
 
-import com.coreos.jetcd.api.*;
-import com.coreos.jetcd.op.Cmp;
-import com.coreos.jetcd.op.CmpTarget;
-import com.coreos.jetcd.op.Op;
-import com.coreos.jetcd.op.Txn;
-import com.coreos.jetcd.options.GetOption;
+import com.coreos.jetcd.api.LeaseKeepAliveResponse;
+import com.coreos.jetcd.api.PutResponse;
+import com.coreos.jetcd.lease.Lease;
 import com.coreos.jetcd.options.PutOption;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.testng.asserts.Assertion;
-
-import java.util.concurrent.ExecutionException;
 
 /**
  * KV service test cases.
@@ -26,8 +20,8 @@ public class EtcdLeaseTest {
     private Assertion test;
 
 
-    private ByteString testKey       = ByteString.copyFromUtf8("foo1");
-    private ByteString testName      = ByteString.copyFromUtf8("bar");
+    private ByteString testKey = ByteString.copyFromUtf8("foo1");
+    private ByteString testName = ByteString.copyFromUtf8("bar");
 
     @BeforeTest
     public void setUp() throws Exception {
@@ -40,8 +34,8 @@ public class EtcdLeaseTest {
 
     @Test
     public void testGrant() throws Exception {
-        long leaseID = leaseClient.grant(5).get().getID();
-        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(leaseID).build()).get();
+        Lease lease = leaseClient.grant(5).get();
+        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(lease).build()).get();
         test.assertEquals(kvClient.get(testKey).get().getCount(), 1);
 
         Thread.sleep(6000);
@@ -50,20 +44,20 @@ public class EtcdLeaseTest {
 
     @Test(dependsOnMethods = "testGrant")
     public void testRevoke() throws Exception {
-        long leaseID = leaseClient.grant(5).get().getID();
-        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(leaseID).build()).get();
+        Lease lease = leaseClient.grant(5).get();
+        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(lease).build()).get();
         test.assertEquals(kvClient.get(testKey).get().getCount(), 1);
-        leaseClient.revoke(leaseID).get();
+        leaseClient.revoke(lease).get();
         test.assertEquals(kvClient.get(testKey).get().getCount(), 0);
     }
 
     @Test(dependsOnMethods = "testRevoke")
     public void testkeepAlive() throws Exception {
-        long leaseID = leaseClient.grant(5).get().getID();
-        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(leaseID).build()).get();
+        Lease lease = leaseClient.grant(5).get();
+        PutResponse putRep = kvClient.put(testKey, testName, PutOption.newBuilder().withLeaseId(lease).build()).get();
         test.assertEquals(kvClient.get(testKey).get().getCount(), 1);
         leaseClient.startKeepAliveService();
-        leaseClient.keepAlive(leaseID, new EtcdLease.EtcdLeaseHandler() {
+        leaseClient.keepAlive(lease, new EtcdLease.EtcdLeaseHandler() {
             @Override
             public void onKeepAliveRespond(LeaseKeepAliveResponse keepAliveResponse) {
 
@@ -81,7 +75,7 @@ public class EtcdLeaseTest {
         });
         Thread.sleep(6000);
         test.assertEquals(kvClient.get(testKey).get().getCount(), 1);
-        leaseClient.cancelKeepAlive(leaseID);
+        leaseClient.cancelKeepAlive(lease);
         test.assertEquals(kvClient.get(testKey).get().getCount(), 0);
     }
 }


### PR DESCRIPTION
With discussion in coreos/jetcd#46  coreos/jetcd#18 coreos/jetcd#16, I convert the ListenableFuture to CompletableFuture and hide the gRPC object.    